### PR TITLE
Add random pride flag printer

### DIFF
--- a/pride/random.go
+++ b/pride/random.go
@@ -1,0 +1,25 @@
+package pride
+
+import (
+	"fmt"
+	"time"
+	"math/rand"
+)
+
+// PrintRandomPrideFlag prints a random pride flag in your terminal.
+func PrintRandomPrideFlag() {
+	rand.Seed(time.Now().UnixNano())
+
+	flagsLen := len(Flags)
+	randFlagIndex := rand.Intn(flagsLen)
+	currFlagIndex := 0
+
+	for pride, printPrideFlag := range Flags {
+		if (currFlagIndex == randFlagIndex) {
+			fmt.Println(pride)
+			printPrideFlag();
+			return
+		}
+		currFlagIndex++
+	}
+}

--- a/pride/random.go
+++ b/pride/random.go
@@ -2,8 +2,8 @@ package pride
 
 import (
 	"fmt"
-	"time"
 	"math/rand"
+	"time"
 )
 
 // PrintRandomPrideFlag prints a random pride flag in your terminal.
@@ -15,9 +15,9 @@ func PrintRandomPrideFlag() {
 	currFlagIndex := 0
 
 	for pride, printPrideFlag := range Flags {
-		if (currFlagIndex == randFlagIndex) {
+		if currFlagIndex == randFlagIndex {
 			fmt.Println(pride)
-			printPrideFlag();
+			printPrideFlag()
 			return
 		}
 		currFlagIndex++


### PR DESCRIPTION
resolves #11 
You can test it by adding `pride.PrintRandomPrideFlag()` to `main.js`

I attempted to use `crypto/rand` to avoid manually seeding, but a lot of extra code had to be added to coerce `int`s to `int64`s to `big.Int`s, so I just stuck with `math/rand`. Lmk if that will be a problem!