### PR TITLE
Limit terminal detection to Linux and Darwin

### DIFF
--- a/pride/wsize_fallback.go
+++ b/pride/wsize_fallback.go
@@ -1,0 +1,7 @@
+// +build !linux,!darwin
+
+package pride
+
+func windowSize() (width, height int) {
+	return 80, 24
+}

--- a/pride/wsize_unix.go
+++ b/pride/wsize_unix.go
@@ -1,3 +1,5 @@
+// +build linux darwin
+
 package pride
 
 import (


### PR DESCRIPTION
Intended to prevent build errors on non-unix variants, by removing `ssh/terminal` from the equation entirely.

As this is a library, we should err on the side of caution and not be causing upstream build failures.